### PR TITLE
Flatten all codes and identifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,5 @@ build/test-results/test/TEST-com.marklogic.hsk.claim.ClaimTest.xml
 marklogic-data-hub-central-5.5.1.war
 
 bin/
+
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ build/reports/tests/test/classes/com.marklogic.hsk.claim.ClaimTest.html
 build/reports/tests/test/packages/com.marklogic.hsk.claim.html
 build/test-results/test/TEST-com.marklogic.hsk.claim.ClaimTest.xml
 marklogic-data-hub-central-5.5.1.war
+
+bin/

--- a/entities/Claim.entity.json
+++ b/entities/Claim.entity.json
@@ -13,12 +13,13 @@
           "sortable": false,
           "collation": "http://marklogic.com/collation/codepoint"
         },
-        "identifier": {
+        "identifier__FILL": {
           "datatype": "array",
           "facetable": false,
           "sortable": false,
           "items": {
-            "$ref": "#/definitions/Identifier"
+            "datatype": "string",
+            "collation": "http://marklogic.com/collation/codepoint"
           }
         },
         "status": {
@@ -27,11 +28,17 @@
           "sortable": false,
           "collation": "http://marklogic.com/collation/codepoint"
         },
-        "type": {
-          "$ref": "#/definitions/CodeableConcept"
+        "code__type": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
         },
-        "subType": {
-          "$ref": "#/definitions/CodeableConcept"
+        "code__subType": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
         },
         "use": {
           "datatype": "string",
@@ -60,11 +67,17 @@
         "provider": {
           "$ref": "#/definitions/Reference"
         },
-        "priority": {
-          "$ref": "#/definitions/CodeableConcept"
+        "code__priority": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
         },
-        "fundsReserve": {
-          "$ref": "#/definitions/CodeableConcept"
+        "code__fundsReserve": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
         },
         "related": {
           "datatype": "array",
@@ -179,120 +192,6 @@
             "datatype": "anyURI",
             "collation": "http://marklogic.com/collation/codepoint"
           }
-        },
-        "security": {
-          "datatype": "array",
-          "facetable": false,
-          "sortable": false,
-          "items": {
-            "$ref": "#/definitions/Coding"
-          }
-        },
-        "tag": {
-          "datatype": "array",
-          "facetable": false,
-          "sortable": false,
-          "items": {
-            "$ref": "#/definitions/Coding"
-          }
-        }
-      }
-    },
-    "Identifier": {
-      "properties": {
-        "id": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "use": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "type": {
-          "$ref": "#/definitions/CodeableConcept"
-        },
-        "system": {
-          "datatype": "anyURI",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "value": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "period": {
-          "$ref": "#/definitions/Period"
-        }
-      }
-    },
-    "CodeableConcept": {
-      "properties": {
-        "id": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "coding": {
-          "datatype": "array",
-          "facetable": false,
-          "sortable": false,
-          "items": {
-            "$ref": "#/definitions/Coding"
-          }
-        },
-        "text": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        }
-      }
-    },
-    "Coding": {
-      "properties": {
-        "id": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "system": {
-          "datatype": "anyURI",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "version": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "code": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "display": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "userSelected": {
-          "datatype": "boolean",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
         }
       }
     },
@@ -315,9 +214,6 @@
           "facetable": false,
           "sortable": false,
           "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "identifier": {
-          "$ref": "#/definitions/Identifier"
         },
         "display": {
           "datatype": "string",
@@ -354,18 +250,21 @@
         "claim": {
           "$ref": "#/definitions/Reference"
         },
-        "relationship": {
-          "$ref": "#/definitions/CodeableConcept"
-        },
-        "reference": {
-          "$ref": "#/definitions/Identifier"
+        "code__relationship": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
         }
       }
     },
     "Payee": {
       "properties": {
-        "type": {
-          "$ref": "#/definitions/CodeableConcept"
+        "code__type": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
         },
         "party": {
           "$ref": "#/definitions/Reference"
@@ -389,11 +288,17 @@
           "sortable": false,
           "collation": "http://marklogic.com/collation/codepoint"
         },
-        "role": {
-          "$ref": "#/definitions/CodeableConcept"
+        "code__role": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
         },
-        "qualification": {
-          "$ref": "#/definitions/CodeableConcept"
+        "code__qualification": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
         }
       }
     },
@@ -405,11 +310,17 @@
           "sortable": false,
           "collation": "http://marklogic.com/collation/codepoint"
         },
-        "category": {
-          "$ref": "#/definitions/CodeableConcept"
+        "code__category": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
         },
-        "code": {
-          "$ref": "#/definitions/CodeableConcept"
+        "code__code": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
         },
         "timingDate": {
           "datatype": "date",
@@ -543,20 +454,38 @@
           "sortable": false,
           "collation": "http://marklogic.com/collation/codepoint"
         },
-        "diagnosisCodeableConcept": {
-          "$ref": "#/definitions/CodeableConcept"
+        "code__diagnosisCodeableConcept_IDC10": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
+        },
+        "code__diagnosisCodeableConcept_SNOMED": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
         },
         "diagnosisReference": {
           "$ref": "#/definitions/Reference"
         },
-        "type": {
-          "$ref": "#/definitions/CodeableConcept"
+        "code__type": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
         },
-        "onAdmission": {
-          "$ref": "#/definitions/CodeableConcept"
+        "code__onAdmission": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
         },
-        "packageCode": {
-          "$ref": "#/definitions/CodeableConcept"
+        "code__packageCode": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
         }
       }
     },
@@ -568,8 +497,11 @@
           "sortable": false,
           "collation": "http://marklogic.com/collation/codepoint"
         },
-        "type": {
-          "$ref": "#/definitions/CodeableConcept"
+        "code__type": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
         },
         "date": {
           "datatype": "date",
@@ -577,8 +509,17 @@
           "sortable": false,
           "collation": "http://marklogic.com/collation/codepoint"
         },
-        "procedureCodeableConcept": {
-          "$ref": "#/definitions/CodeableConcept"
+        "code__procedureCodeableConcept__ICD10": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
+        },
+        "code__procedureCodeableConcept__SNOMED": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
         },
         "procedureReference": {
           "$ref": "#/definitions/Reference"
@@ -602,8 +543,11 @@
           "sortable": false,
           "collation": "http://marklogic.com/collation/codepoint"
         },
-        "identifier": {
-          "$ref": "#/definitions/Identifier"
+        "identifier__NIIP": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
         },
         "coverage": {
           "$ref": "#/definitions/Reference"
@@ -633,8 +577,11 @@
           "sortable": false,
           "collation": "http://marklogic.com/collation/codepoint"
         },
-        "type": {
-          "$ref": "#/definitions/CodeableConcept"
+        "code__type": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
         },
         "locationAddress": {
           "$ref": "#/definitions/Address"
@@ -688,29 +635,40 @@
             "collation": "http://marklogic.com/collation/codepoint"
           }
         },
-        "revenue": {
-          "$ref": "#/definitions/CodeableConcept"
+        "code__revenue": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
         },
-        "category": {
-          "$ref": "#/definitions/CodeableConcept"
+        "code__category": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
         },
-        "productOrService": {
-          "$ref": "#/definitions/CodeableConcept"
+        "code__productOrService": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
         },
-        "modifier": {
+        "code__modifier": {
           "datatype": "array",
           "facetable": false,
           "sortable": false,
           "items": {
-            "$ref": "#/definitions/CodeableConcept"
+            "datatype": "string",
+            "collation": "http://marklogic.com/collation/codepoint"
           }
         },
-        "programCode": {
+        "code__programCode": {
           "datatype": "array",
           "facetable": false,
           "sortable": false,
           "items": {
-            "$ref": "#/definitions/CodeableConcept"
+            "datatype": "string",
+            "collation": "http://marklogic.com/collation/codepoint"
           }
         },
         "servicedDate": {
@@ -722,8 +680,11 @@
         "servicedPeriod": {
           "$ref": "#/definitions/Period"
         },
-        "locationCodeableConcept": {
-          "$ref": "#/definitions/CodeableConcept"
+        "code__locationCodeableConcept": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
         },
         "locationAddress": {
           "$ref": "#/definitions/Address"
@@ -749,15 +710,19 @@
         "udi": {
           "$ref": "#/definitions/Reference"
         },
-        "bodySite": {
-          "$ref": "#/definitions/CodeableConcept"
+        "code__bodySite": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
         },
-        "subSite": {
+        "code__subSite": {
           "datatype": "array",
           "facetable": false,
           "sortable": false,
           "items": {
-            "$ref": "#/definitions/CodeableConcept"
+            "datatype": "string",
+            "collation": "http://marklogic.com/collation/codepoint"
           }
         },
         "encounter": {
@@ -900,29 +865,40 @@
           "sortable": false,
           "collation": "http://marklogic.com/collation/codepoint"
         },
-        "revenue": {
-          "$ref": "#/definitions/CodeableConcept"
+        "code__revenue": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
         },
-        "category": {
-          "$ref": "#/definitions/CodeableConcept"
+        "code__category": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
         },
-        "productOrService": {
-          "$ref": "#/definitions/CodeableConcept"
+        "code__productOrService": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
         },
-        "modifier": {
+        "code__modifier": {
           "datatype": "array",
           "facetable": false,
           "sortable": false,
           "items": {
-            "$ref": "#/definitions/CodeableConcept"
+            "datatype": "string",
+            "collation": "http://marklogic.com/collation/codepoint"
           }
         },
-        "programCode": {
+        "code__programCode": {
           "datatype": "array",
           "facetable": false,
           "sortable": false,
           "items": {
-            "$ref": "#/definitions/CodeableConcept"
+            "datatype": "string",
+            "collation": "http://marklogic.com/collation/codepoint"
           }
         },
         "quantity": {
@@ -961,29 +937,40 @@
           "sortable": false,
           "collation": "http://marklogic.com/collation/codepoint"
         },
-        "revenue": {
-          "$ref": "#/definitions/CodeableConcept"
+        "code__revenue": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
         },
-        "category": {
-          "$ref": "#/definitions/CodeableConcept"
+        "code__category": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
         },
-        "productOrService": {
-          "$ref": "#/definitions/CodeableConcept"
+        "code__productOrService": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
         },
-        "modifier": {
+        "code__modifier": {
           "datatype": "array",
           "facetable": false,
           "sortable": false,
           "items": {
-            "$ref": "#/definitions/CodeableConcept"
+            "datatype": "string",
+            "collation": "http://marklogic.com/collation/codepoint"
           }
         },
-        "programCode": {
+        "code__programCode": {
           "datatype": "array",
           "facetable": false,
           "sortable": false,
           "items": {
-            "$ref": "#/definitions/CodeableConcept"
+            "datatype": "string",
+            "collation": "http://marklogic.com/collation/codepoint"
           }
         },
         "quantity": {

--- a/entities/Location.entity.json
+++ b/entities/Location.entity.json
@@ -156,33 +156,11 @@
             "datatype": "anyURI",
             "collation": "http://marklogic.com/collation/codepoint"
           }
-        },
-        "security": {
-          "datatype": "array",
-          "facetable": false,
-          "sortable": false,
-          "items": {
-            "$ref": "#/definitions/Coding"
-          }
-        },
-        "tag": {
-          "datatype": "array",
-          "facetable": false,
-          "sortable": false,
-          "items": {
-            "$ref": "#/definitions/Coding"
-          }
         }
       }
     },
     "Narrative": {
       "properties": {
-        "id": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
         "status": {
           "datatype": "string",
           "facetable": false,
@@ -197,51 +175,8 @@
         }
       }
     },
-    "Extension": {
-      "properties": { }
-    },
-    "Identifier": {
-      "properties": {
-        "id": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "use": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "type": {
-          "$ref": "#/definitions/CodeableConcept"
-        },
-        "system": {
-          "datatype": "anyURI",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "value": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "period": {
-          "$ref": "#/definitions/Period"
-        }
-      }
-    },
     "Period": {
       "properties": {
-        "id": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
         "start": {
           "datatype": "string",
           "facetable": false,
@@ -256,78 +191,8 @@
         }
       }
     },
-    "Coding": {
-      "properties": {
-        "id": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "system": {
-          "datatype": "anyURI",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "version": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "code": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "display": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "userSelected": {
-          "datatype": "boolean",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        }
-      }
-    },
-    "CodeableConcept": {
-      "properties": {
-        "id": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "coding": {
-          "datatype": "array",
-          "facetable": false,
-          "sortable": false,
-          "items": {
-            "$ref": "#/definitions/Coding"
-          }
-        },
-        "text": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        }
-      }
-    },
     "ContactPoint": {
       "properties": {
-        "id": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
         "system": {
           "datatype": "string",
           "facetable": false,
@@ -359,12 +224,6 @@
     },
     "Address": {
       "properties": {
-        "id": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
         "use": {
           "datatype": "string",
           "facetable": false,
@@ -429,12 +288,6 @@
     },
     "Position": {
       "properties": {
-        "id": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
         "longitude": {
           "datatype": "decimal",
           "facetable": false,
@@ -460,12 +313,6 @@
     },
     "HoursOfOperation": {
       "properties": {
-        "id": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
         "daysOfWeek": {
           "datatype": "array",
           "facetable": false,

--- a/entities/Organization.entity.json
+++ b/entities/Organization.entity.json
@@ -22,14 +22,6 @@
         "text": {
           "$ref": "#/definitions/Narrative"
         },
-        "identifier": {
-          "datatype": "array",
-          "facetable": false,
-          "sortable": false,
-          "items": {
-            "$ref": "#/definitions/Identifier"
-          }
-        },
         "active": {
           "datatype": "boolean",
           "facetable": false,
@@ -107,14 +99,11 @@
     },
     "Contact": {
       "properties": {
-        "id": {
+        "code__purpose": {
           "datatype": "string",
           "facetable": false,
           "sortable": false,
           "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "purpose": {
-          "$ref": "#/definitions/CodeableConcept"
         },
         "name": {
           "$ref": "#/definitions/HumanName"
@@ -146,8 +135,11 @@
           "sortable": false,
           "collation": "http://marklogic.com/collation/codepoint"
         },
-        "type": {
-          "$ref": "#/definitions/CodeableConcept"
+        "code__type": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
         },
         "system": {
           "datatype": "anyURI",
@@ -226,12 +218,6 @@
     },
     "ContactPoint": {
       "properties": {
-        "id": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
         "system": {
           "datatype": "string",
           "facetable": false,
@@ -406,62 +392,6 @@
             "datatype": "anyURI",
             "collation": "http://marklogic.com/collation/codepoint"
           }
-        },
-        "security": {
-          "datatype": "array",
-          "facetable": false,
-          "sortable": false,
-          "items": {
-            "$ref": "#/definitions/Coding"
-          }
-        },
-        "tag": {
-          "datatype": "array",
-          "facetable": false,
-          "sortable": false,
-          "items": {
-            "$ref": "#/definitions/Coding"
-          }
-        }
-      }
-    },
-    "Coding": {
-      "properties": {
-        "id": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "system": {
-          "datatype": "anyURI",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "version": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "code": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "display": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "userSelected": {
-          "datatype": "boolean",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
         }
       }
     },
@@ -480,30 +410,6 @@
           "collation": "http://marklogic.com/collation/codepoint"
         },
         "div": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        }
-      }
-    },
-    "CodeableConcept": {
-      "properties": {
-        "id": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "coding": {
-          "datatype": "array",
-          "facetable": false,
-          "sortable": false,
-          "items": {
-            "$ref": "#/definitions/Coding"
-          }
-        },
-        "text": {
           "datatype": "string",
           "facetable": false,
           "sortable": false,
@@ -531,9 +437,6 @@
           "sortable": false,
           "collation": "http://marklogic.com/collation/codepoint"
         },
-        "identifier": {
-          "$ref": "#/definitions/Identifier"
-        },
         "display": {
           "datatype": "string",
           "facetable": false,
@@ -544,16 +447,11 @@
     },
     "DavinciQualificationExtension": {
       "properties": {
-        "identifier": {
-          "datatype": "array",
+        "code__code": {
+          "datatype": "string",
           "facetable": false,
           "sortable": false,
-          "items": {
-            "$ref": "#/definitions/Identifier"
-          }
-        },
-        "code": {
-          "$ref": "#/definitions/CodeableConcept"
+          "collation": "http://marklogic.com/collation/codepoint"
         },
         "issuer": {
           "$ref": "#/definitions/Reference"
@@ -567,12 +465,13 @@
         "period": {
           "$ref": "#/definitions/Period"
         },
-        "whereValidCodeableConcept": {
+        "code__whereValid": {
           "datatype": "array",
           "facetable": false,
           "sortable": false,
           "items": {
-            "$ref": "#/definitions/CodeableConcept"
+            "datatype": "string",
+            "collation": "http://marklogic.com/collation/codepoint"
           }
         },
         "whereValidReference": {

--- a/entities/Patient.entity.json
+++ b/entities/Patient.entity.json
@@ -278,74 +278,13 @@
         }
       }
     },
-    "CodeableConcept": {
-      "properties": {
-        "id": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "coding": {
-          "datatype": "array",
-          "facetable": false,
-          "sortable": false,
-          "items": {
-            "$ref": "#/definitions/Coding"
-          }
-        },
-        "text": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        }
-      }
-    },
-    "Coding": {
-      "properties": {
-        "id": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "system": {
-          "datatype": "anyURI",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "version": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "code": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "display": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "userSelected": {
-          "datatype": "boolean",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        }
-      }
-    },
     "Communication": {
       "properties": {
-        "language": {
-          "$ref": "#/definitions/CodeableConcept"
+        "code__language": {
+          "datatype": "string",
+          "facetable": false,
+          "sortable": false,
+          "collation": "http://marklogic.com/collation/codepoint"
         },
         "preferred": {
           "datatype": "boolean",
@@ -357,12 +296,13 @@
     },
     "Contact": {
       "properties": {
-        "relationship": {
+        "code__relationship": {
           "datatype": "array",
           "facetable": false,
           "sortable": false,
           "items": {
-            "$ref": "#/definitions/CodeableConcept"
+            "datatype": "string",
+            "collation": "http://marklogic.com/collation/codepoint"
           }
         },
         "name": {
@@ -477,40 +417,6 @@
         }
       }
     },
-    "Identifier": {
-      "properties": {
-        "id": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "use": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "type": {
-          "$ref": "#/definitions/CodeableConcept"
-        },
-        "system": {
-          "datatype": "anyURI",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "value": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "period": {
-          "$ref": "#/definitions/Period"
-        }
-      }
-    },
     "Meta": {
       "properties": {
         "id": {
@@ -544,22 +450,6 @@
           "items": {
             "datatype": "anyURI",
             "collation": "http://marklogic.com/collation/codepoint"
-          }
-        },
-        "security": {
-          "datatype": "array",
-          "facetable": false,
-          "sortable": false,
-          "items": {
-            "$ref": "#/definitions/Coding"
-          }
-        },
-        "tag": {
-          "datatype": "array",
-          "facetable": false,
-          "sortable": false,
-          "items": {
-            "$ref": "#/definitions/Coding"
           }
         }
       }

--- a/entities/Practitioner.entity.json
+++ b/entities/Practitioner.entity.json
@@ -111,40 +111,6 @@
         }
       }
     },
-    "Identifier": {
-      "properties": {
-        "id": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "use": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "type": {
-          "$ref": "#/definitions/CodeableConcept"
-        },
-        "system": {
-          "datatype": "anyURI",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "value": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "period": {
-          "$ref": "#/definitions/Period"
-        }
-      }
-    },
     "HumanName": {
       "properties": {
         "id": {
@@ -366,62 +332,6 @@
             "datatype": "anyURI",
             "collation": "http://marklogic.com/collation/codepoint"
           }
-        },
-        "security": {
-          "datatype": "array",
-          "facetable": false,
-          "sortable": false,
-          "items": {
-            "$ref": "#/definitions/Coding"
-          }
-        },
-        "tag": {
-          "datatype": "array",
-          "facetable": false,
-          "sortable": false,
-          "items": {
-            "$ref": "#/definitions/Coding"
-          }
-        }
-      }
-    },
-    "Coding": {
-      "properties": {
-        "id": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "system": {
-          "datatype": "anyURI",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "version": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "code": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "display": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "userSelected": {
-          "datatype": "boolean",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
         }
       }
     },
@@ -513,16 +423,11 @@
           "sortable": false,
           "collation": "http://marklogic.com/collation/codepoint"
         },
-        "identifier": {
-          "datatype": "array",
+        "code__code": {
+          "datatype": "string",
           "facetable": false,
           "sortable": false,
-          "items": {
-            "$ref": "#/definitions/Identifier"
-          }
-        },
-        "code": {
-          "$ref": "#/definitions/CodeableConcept"
+          "collation": "http://marklogic.com/collation/codepoint"
         },
         "period": {
           "$ref": "#/definitions/Period"
@@ -560,14 +465,6 @@
           "facetable": false,
           "sortable": false,
           "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "identifier": {
-          "datatype": "array",
-          "facetable": false,
-          "sortable": false,
-          "items": {
-            "$ref": "#/definitions/Identifier"
-          }
         },
         "name": {
           "$ref": "#/definitions/HumanName"

--- a/entities/PractitionerRole.entity.json
+++ b/entities/PractitionerRole.entity.json
@@ -55,12 +55,6 @@
     },
     "Meta": {
       "properties": {
-        "id": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
         "versionId": {
           "datatype": "string",
           "facetable": false,
@@ -87,32 +81,11 @@
             "datatype": "anyURI",
             "collation": "http://marklogic.com/collation/codepoint"
           }
-        },
-        "security": {
-          "datatype": "array",
-          "facetable": false,
-          "sortable": false,
-          "items": {
-            "$ref": "#/definitions/Coding"
-          }
-        },
-        "tag": {
-          "datatype": "array",
-          "facetable": false,
-          "sortable": false,
-          "items": {
-            "$ref": "#/definitions/Coding"
-          }
         }
       }
     },
     "Reference": {
       "properties": {
-        "id": {
-          "datatype": "string",
-          "relatedEntityType": "http://example.org/Practitioner-1.0.0/Practitioner",
-          "joinPropertyName": "id"
-        },
         "reference": {
           "datatype": "string",
           "facetable": false,
@@ -125,123 +98,16 @@
           "sortable": false,
           "collation": "http://marklogic.com/collation/codepoint"
         },
-        "identifier": {
-          "$ref": "#/definitions/Identifier"
-        },
         "display": {
           "datatype": "string",
           "facetable": false,
           "sortable": false,
           "collation": "http://marklogic.com/collation/codepoint"
-        }
-      }
-    },
-    "CodeableConcept": {
-      "properties": {
-        "id": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "coding": {
-          "datatype": "array",
-          "facetable": false,
-          "sortable": false,
-          "items": {
-            "$ref": "#/definitions/Coding"
-          }
-        },
-        "text": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        }
-      }
-    },
-    "Coding": {
-      "properties": {
-        "id": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "system": {
-          "datatype": "anyURI",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "version": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "code": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "display": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "userSelected": {
-          "datatype": "boolean",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        }
-      }
-    },
-    "Identifier": {
-      "properties": {
-        "id": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "use": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "type": {
-          "$ref": "#/definitions/CodeableConcept"
-        },
-        "system": {
-          "datatype": "anyURI",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "value": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
-        "period": {
-          "$ref": "#/definitions/Period"
         }
       }
     },
     "Period": {
       "properties": {
-        "id": {
-          "datatype": "string",
-          "facetable": false,
-          "sortable": false,
-          "collation": "http://marklogic.com/collation/codepoint"
-        },
         "start": {
           "datatype": "string",
           "facetable": false,

--- a/src/test/java/com/marklogic/hsk/claim/ClaimTest.java
+++ b/src/test/java/com/marklogic/hsk/claim/ClaimTest.java
@@ -49,10 +49,8 @@ public class ClaimTest {
     public void testClaimFinal() {
         JsonNode finalDoc = client.newJSONDocumentManager().read("/claim/0a8c5c5f-46ff-28b5-3cba-309d1c4637fa.json", new JacksonHandle()).get();
         assertEquals("0a8c5c5f-46ff-28b5-3cba-309d1c4637fa", finalDoc.get("envelope").get("instance").get("Claim").get("id").asText());
-        assertEquals("http://hl7.org/fhir/ValueSet/payeetype", finalDoc.get("envelope").get("instance").get("Claim").get("payee").get("Payee").get("type").get("CodeableConcept").get("coding").get(0).get("Coding").get("system").asText());
-        assertEquals("provider", finalDoc.get("envelope").get("instance").get("Claim").get("payee").get("Payee").get("type").get("CodeableConcept").get("coding").get(0).get("Coding").get("code").asText());
-        assertEquals("Provider", finalDoc.get("envelope").get("instance").get("Claim").get("payee").get("Payee").get("type").get("CodeableConcept").get("coding").get(0).get("Coding").get("display").asText());
-        assertEquals("702927004", finalDoc.get("envelope").get("instance").get("Claim").get("procedure").get(0).get("Procedure").get("procedureCodeableConcept").get("CodeableConcept").get("coding").get(0).get("Coding").get("code").asText());
+        assertEquals("provider", finalDoc.get("envelope").get("instance").get("Claim").get("payee").get("Payee").get("code__type").asText());
+        assertEquals("702927004", finalDoc.get("envelope").get("instance").get("Claim").get("procedure").get(0).get("Procedure").get("code__procedureCodeableConcept__SNOMED").asText());
         assertEquals(2, finalDoc.get("envelope").get("instance").get("Claim").get("item").size());
         assertEquals("102.15", finalDoc.get("envelope").get("instance").get("Claim").get("total").get("Money").get("value").asText());
         assertEquals("WELLSTAR URGENT CARE - DELK ROAD, 2890 DELK ROAD SOUTHEAST, MARIETTA, GA, 30067", finalDoc.get("envelope").get("instance").get("Claim").get("item").get(0).get("ClaimItem").get("locationAddress").get("Address").get("text").asText());

--- a/src/test/ml-modules/root/test/suites/ClaimSuite/test.sjs
+++ b/src/test/ml-modules/root/test/suites/ClaimSuite/test.sjs
@@ -69,12 +69,12 @@ const content = result.contentArray[0];
 const context = content.context;
 const claim = content.value.toObject().envelope.instance.Claim;
 
+xdmp.log(xdmp.quote(claim)) 
+
 assertions.push(
   test.assertEqual("0a8c5c5f-46ff-28b5-3cba-309d1c4637fa", claim.id),
-  test.assertEqual("http://hl7.org/fhir/ValueSet/payeetype", claim.payee.Payee.type.CodeableConcept.coding[0].Coding.system),
-  test.assertEqual("provider", claim.payee.Payee.type.CodeableConcept.coding[0].Coding.code),
-  test.assertEqual("Provider", claim.payee.Payee.type.CodeableConcept.coding[0].Coding.display),
-  test.assertEqual("702927004", claim.procedure[0].Procedure.procedureCodeableConcept.CodeableConcept.coding[0].Coding.code),
+  test.assertEqual("provider", claim.payee.Payee.code__type),
+  test.assertEqual("702927004", claim.procedure[0].Procedure.code__procedureCodeableConcept__SNOMED),
   test.assertEqual(2, claim.item.length),
   test.assertEqual("102.15", xs.string(claim.total.Money.value)),
   test.assertEqual("WELLSTAR URGENT CARE - DELK ROAD, 2890 DELK ROAD SOUTHEAST, MARIETTA, GA, 30067", claim.item[0].ClaimItem.locationAddress.Address.text),

--- a/steps/mapping/ClaimMapping.step.json
+++ b/steps/mapping/ClaimMapping.step.json
@@ -49,68 +49,11 @@
     "status": {
       "sourcedFrom": "valueSetLookup(\"active\", \"fm-status\")/code"
     },
-    "type": {
-      "sourcedFrom": ".",
-      "properties": {
-        "coding": {
-          "sourcedFrom": ".",
-          "properties": {
-            "system": {
-              "sourcedFrom": "\"http://terminology.hl7.org/CodeSystem/claim-type\""
-            },
-            "id": {
-              "sourcedFrom": ""
-            },
-            "code": {
-              "sourcedFrom": "valueSetLookup(\"institutional\", \"claim-type\")/code"
-            },
-            "display": {
-              "sourcedFrom": "valueSetLookup(\"institutional\", \"claim-type\")/display"
-            }
-          },
-          "targetEntityType": "#/definitions/Coding"
-        },
-        "text": {
-          "sourcedFrom": "valueSetLookup(\"institutional\", \"claim-type\")/display"
-        }
-      },
-      "targetEntityType": "#/definitions/CodeableConcept"
+    "code__type": {
+      "sourcedFrom": "\"institutional\""
     },
-    "identifier": {
-      "sourcedFrom": ".",
-      "properties": {
-        "value": {
-          "sourcedFrom": "Id/normalize-space()"
-        },
-        "system": {
-          "sourcedFrom": "\"http://marklogic.com/hsk/fhir/v4/Claim\""
-        },
-        "use": {
-          "sourcedFrom": "valueSetLookup(\"official\", \"identifier-use\")/code"
-        },
-        "type": {
-          "sourcedFrom": ".",
-          "properties": {
-            "coding": {
-              "sourcedFrom": ".",
-              "properties": {
-                "code": {
-                  "sourcedFrom": "valueSetLookup(\"FILL\", \"identifier-type\")/code"
-                },
-                "display": {
-                  "sourcedFrom": "valueSetLookup(\"FILL\", \"identifier-type\")/display"
-                }
-              },
-              "targetEntityType": "#/definitions/Coding"
-            },
-            "text": {
-              "sourcedFrom": "valueSetLookup(\"FILL\", \"identifier-type\")/display"
-            }
-          },
-          "targetEntityType": "#/definitions/CodeableConcept"
-        }
-      },
-      "targetEntityType": "#/definitions/Identifier"
+    "identifier__FILL": {
+      "sourcedFrom": "Id/normalize-space()"
     },
     "provider": {
       "sourcedFrom": ".",
@@ -120,51 +63,6 @@
         },
         "type": {
           "sourcedFrom": "\"Practitioner\""
-        },
-        "identifier": {
-          "sourcedFrom": ".",
-          "properties": {
-            "use": {
-              "sourcedFrom": "valueSetLookup(\"usual\", \"identifier-use\")/code"
-            },
-            "type": {
-              "sourcedFrom": ".",
-              "properties": {
-                "coding": {
-                  "sourcedFrom": ".",
-                  "properties": {
-                    "system": {
-                      "sourcedFrom": "\"http://terminology.hl7.org/CodeSystem/v2-0203\""
-                    },
-                    "code": {
-                      "sourcedFrom": "valueSetLookup(\"FILL\", \"identifier-type\")/code"
-                    },
-                    "display": {
-                      "sourcedFrom": "valueSetLookup(\"FILL\", \"identifier-type\")/display"
-                    },
-                    "userSelected": {
-                      "sourcedFrom": "false()"
-                    }
-                  },
-                  "targetEntityType": "#/definitions/Coding"
-                },
-                "text": {
-                  "sourcedFrom": "valueSetLookup(\"FILL\", \"identifier-type\")/display"
-                }
-              },
-              "targetEntityType": "#/definitions/CodeableConcept"
-            },
-            "system": {
-              "sourcedFrom": "\"http://hl7.org/fhir/identifier-use\""
-            },
-            "value": {
-              "sourcedFrom": "concat(\"Provider/\", PROVIDERID/normalize-space())"
-            }
-          },
-          "targetEntityType": "#/definitions/Identifier"
-        },
-        "display": {
-          "sourcedFrom": "PROVIDERID/normalize-space()"
         }
       },
       "targetEntityType": "#/definitions/Reference"
@@ -181,29 +79,8 @@
       },
       "targetEntityType": "#/definitions/Reference"
     },
-    "priority": {
-      "sourcedFrom": ".",
-      "properties": {
-        "text": {
-          "sourcedFrom": "valueSetLookup(\"normal\", \"process-priority\")/display"
-        },
-        "coding": {
-          "sourcedFrom": ".",
-          "properties": {
-            "system": {
-              "sourcedFrom": "\"http://terminology.hl7.org/CodeSystem/processpriority\""
-            },
-            "code": {
-              "sourcedFrom": "valueSetLookup(\"normal\", \"process-priority\")/code"
-            },
-            "display": {
-              "sourcedFrom": "valueSetLookup(\"normal\", \"process-priority\")/display"
-            }
-          },
-          "targetEntityType": "#/definitions/Coding"
-        }
-      },
-      "targetEntityType": "#/definitions/CodeableConcept"
+    "code__priority": {
+      "sourcedFrom": "\"normal\""
     },
     "billablePeriod": {
       "sourcedFrom": ".",
@@ -232,62 +109,20 @@
       },
       "targetEntityType": "#/definitions/Reference"
     },
-    "fundsReserve": {
-      "sourcedFrom": ".",
-      "properties": {
-        "coding": {
-          "sourcedFrom": ".",
-          "properties": {
-            "system": {
-              "sourcedFrom": "\"http://hl7.org/fhir/ValueSet/fundsreserve\""
-            },
-            "code": {
-              "sourcedFrom": "valueSetLookup(\"none\", \"fundsreserve\")/code"
-            },
-            "display": {
-              "sourcedFrom": "valueSetLookup(\"none\", \"fundsreserve\")/display"
-            }
-          },
-          "targetEntityType": "#/definitions/Coding"
-        },
-        "text": {
-          "sourcedFrom": "valueSetLookup(\"none\", \"fundsreserve\")/display"
-        }
-      },
-      "targetEntityType": "#/definitions/CodeableConcept"
+    "code__fundsReserve": {
+      "sourcedFrom": "\"none\""
     },
     "payee": {
       "sourcedFrom": ".",
       "properties": {
-        "type": {
-          "sourcedFrom": ".",
-          "properties": {
-            "coding": {
-              "sourcedFrom": ".",
-              "properties": {
-                "system": {
-                  "sourcedFrom": "\"http://hl7.org/fhir/ValueSet/payeetype\""
-                },
-                "code": {
-                  "sourcedFrom": "valueSetLookup(\"provider\", \"payeetype\")/code"
-                },
-                "display": {
-                  "sourcedFrom": "valueSetLookup(\"provider\", \"payeetype\")/display"
-                }
-              },
-              "targetEntityType": "#/definitions/Coding"
-            },
-            "text": {
-              "sourcedFrom": "valueSetLookup(\"provider\", \"payeetype\")/display"
-            }
-          },
-          "targetEntityType": "#/definitions/CodeableConcept"
+        "code__type": {
+          "sourcedFrom": "\"provider\""
         },
         "party": {
           "sourcedFrom": ".",
           "properties": {
             "reference": {
-              "sourcedFrom": "concat(\"Provider/\", PROVIDERID/normalize-space())"
+              "sourcedFrom": "concat(\"Practitioner/\", PROVIDERID/normalize-space())"
             },
             "type": {
               "sourcedFrom": "\"Practitioner\""
@@ -319,38 +154,8 @@
         "responsible": {
           "sourcedFrom": "true()"
         },
-        "role": {
-          "sourcedFrom": ".",
-          "properties": {
-            "text": {
-              "sourcedFrom": "valueSetLookup(\"primary\", \"claim-caretyperole\")/display"
-            },
-            "coding": {
-              "sourcedFrom": ".",
-              "properties": {
-                "system": {
-                  "sourcedFrom": "\"http://terminology.hl7.org/CodeSystem/claimcareteamrole\""
-                },
-                "code": {
-                  "sourcedFrom": "valueSetLookup(\"primary\", \"claim-caretyperole\")/code"
-                },
-                "display": {
-                  "sourcedFrom": "valueSetLookup(\"primary\", \"claim-caretyperole\")/display"
-                },
-                "userSelected": {
-                  "sourcedFrom": "false()"
-                },
-                "version": {
-                  "sourcedFrom": ""
-                }
-              },
-              "targetEntityType": "#/definitions/Coding"
-            }
-          },
-          "targetEntityType": "#/definitions/CodeableConcept"
-        },
-        "qualification": {
-          "sourcedFrom": ""
+        "code__role": {
+          "sourcedFrom": "\"primary\""
         }
       },
       "targetEntityType": "#/definitions/CareTeamMember"
@@ -361,32 +166,8 @@
         "sequence": {
           "sourcedFrom": "position()"
         },
-        "diagnosisCodeableConcept": {
-          "sourcedFrom": ".",
-          "properties": {
-            "coding": {
-              "sourcedFrom": ".",
-              "properties": {
-                "code": {
-                  "sourcedFrom": "."
-                },
-                "userSelected": {
-                  "sourcedFrom": "false()"
-                },
-                "system": {
-                  "sourcedFrom": "\"http://snomed.info/sct\""
-                },
-                "display": {
-                  "sourcedFrom": "."
-                }
-              },
-              "targetEntityType": "#/definitions/Coding"
-            },
-            "text": {
-              "sourcedFrom": "."
-            }
-          },
-          "targetEntityType": "#/definitions/CodeableConcept"
+        "code__diagnosisCodeableConcept_SNOMED": {
+          "sourcedFrom": "."
         }
       },
       "targetEntityType": "#/definitions/Diagnosis"
@@ -398,61 +179,13 @@
           "sourcedFrom": "position()"
         },
         "type": {
-          "sourcedFrom": ".",
-          "properties": {
-            "id": {
-              "sourcedFrom": ""
-            },
-            "coding": {
-              "sourcedFrom": ".",
-              "properties": {
-                "system": {
-                  "sourcedFrom": "\"http://hl7.org/fhir/sid/ex-icd-10-procedures\""
-                },
-                "code": {
-                  "sourcedFrom": "\"primary\""
-                },
-                "display": {
-                  "sourcedFrom": "\"Primary procedure\""
-                },
-                "userSelected": {
-                  "sourcedFrom": "false()"
-                }
-              },
-              "targetEntityType": "#/definitions/Coding"
-            },
-            "text": {
-              "sourcedFrom": "\"Primary procedure\""
-            }
-          },
-          "targetEntityType": "#/definitions/CodeableConcept"
+          "sourcedFrom": "\"primary\""
         },
         "date": {
           "sourcedFrom": "substring-before(./claimLine/TODATE, \"T\")"
         },
         "procedureCodeableConcept": {
-          "sourcedFrom": ".",
-          "properties": {
-            "coding": {
-              "sourcedFrom": ".",
-              "properties": {
-                "system": {
-                  "sourcedFrom": "\"http://hl7.org/fhir/sid/ex-icd-10-procedures\""
-                },
-                "code": {
-                  "sourcedFrom": "./claimLine/PROCEDURECODE"
-                },
-                "display": {
-                  "sourcedFrom": "./claimLine/NOTES"
-                }
-              },
-              "targetEntityType": "#/definitions/Coding"
-            },
-            "text": {
-              "sourcedFrom": "./claimLine/NOTES"
-            }
-          },
-          "targetEntityType": "#/definitions/CodeableConcept"
+          "sourcedFrom": "./claimLine/PROCEDURECODE"
         }
       },
       "targetEntityType": "#/definitions/Procedure"
@@ -466,44 +199,8 @@
         "focal": {
           "sourcedFrom": "true()"
         },
-        "identifier": {
-          "sourcedFrom": ".",
-          "properties": {
-            "use": {
-              "sourcedFrom": "valueSetLookup(\"official\", \"identifier-use\")/code"
-            },
-            "type": {
-              "sourcedFrom": ".",
-              "properties": {
-                "coding": {
-                  "sourcedFrom": ".",
-                  "properties": {
-                    "code": {
-                      "sourcedFrom": "valueSetLookup(\"NIIP\", \"identifier-type\")/code"
-                    },
-                    "display": {
-                      "sourcedFrom": "valueSetLookup(\"NIIP\", \"identifier-type\")/display"
-                    },
-                    "system": {
-                      "sourcedFrom": "\"http://terminology.hl7.org/CodeSystem/v2-0203\""
-                    }
-                  },
-                  "targetEntityType": "#/definitions/Coding"
-                },
-                "text": {
-                  "sourcedFrom": "valueSetLookup(\"NIIP\", \"identifier-type\")/display"
-                }
-              },
-              "targetEntityType": "#/definitions/CodeableConcept"
-            },
-            "value": {
-              "sourcedFrom": "."
-            },
-            "system": {
-              "sourcedFrom": "\"http://terminology.hl7.org/CodeSystem/v2-0203\""
-            }
-          },
-          "targetEntityType": "#/definitions/Identifier"
+        "identifier__NIIP": {
+          "sourcedFrom": "."
         },
         "coverage": {
           "sourcedFrom": ".",
@@ -566,61 +263,10 @@
           "targetEntityType": "#/definitions/Period"
         },
         "category": {
-          "sourcedFrom": ".",
-          "properties": {
-            "coding": {
-              "sourcedFrom": ".",
-              "properties": {
-                "system": {
-                  "sourcedFrom": "\"http://terminology.hl7.org/CodeSystem/ex-benefitcategory\""
-                },
-                "version": {
-                  "sourcedFrom": ""
-                },
-                "code": {
-                  "sourcedFrom": "valueSetLookup(\"1\", \"ex-benefitcategory\")/code"
-                },
-                "display": {
-                  "sourcedFrom": "valueSetLookup(\"1\", \"ex-benefitcategory\")/display"
-                },
-                "userSelected": {
-                  "sourcedFrom": "false()"
-                }
-              },
-              "targetEntityType": "#/definitions/Coding"
-            },
-            "text": {
-              "sourcedFrom": "valueSetLookup(\"1\", \"ex-benefitcategory\")/display"
-            }
-          },
-          "targetEntityType": "#/definitions/CodeableConcept"
+          "sourcedFrom": "\"1\""
         },
         "productOrService": {
-          "sourcedFrom": ".",
-          "properties": {
-            "coding": {
-              "sourcedFrom": ".",
-              "properties": {
-                "system": {
-                  "sourcedFrom": "\"http://terminology.hl7.org/CodeSystem/ex-USCLS\""
-                },
-                "code": {
-                  "sourcedFrom": "valueSetLookup(\"99555\", \"service-uscls\")/code"
-                },
-                "display": {
-                  "sourcedFrom": "valueSetLookup(\"99555\", \"service-uscls\")/display"
-                },
-                "userSelected": {
-                  "sourcedFrom": "false()"
-                }
-              },
-              "targetEntityType": "#/definitions/Coding"
-            },
-            "text": {
-              "sourcedFrom": "valueSetLookup(\"99555\", \"service-uscls\")/display"
-            }
-          },
-          "targetEntityType": "#/definitions/CodeableConcept"
+          "sourcedFrom": "\"99555\""
         },
         "locationAddress": {
           "sourcedFrom": "claimGetOrganizationLocation(./claimLine/PLACEOFSERVICE/normalize-space())",
@@ -656,28 +302,10 @@
           "sourcedFrom": ".",
           "properties": {
             "reference": {
-              "sourcedFrom": "\"internal\""
+              "sourcedFrom": "concat(\"Location/\", ./claimLine/PLACEOFSERVICE/normalize-space())"
             },
             "type": {
               "sourcedFrom": "\"Location\""
-            },
-            "identifier": {
-              "sourcedFrom": ".",
-              "properties": {
-                "value": {
-                  "sourcedFrom": "concat(\"Location/\", ./claimLine/PLACEOFSERVICE/normalize-space())"
-                },
-                "use": {
-                  "sourcedFrom": "valueSetLookup(\"usual\", \"identifier-use\")/code"
-                },
-                "system": {
-                  "sourcedFrom": "\"http://hl7.org/fhir/identifier-use\""
-                }
-              },
-              "targetEntityType": "#/definitions/Identifier"
-            },
-            "display": {
-              "sourcedFrom": "./claimLine/PLACEOFSERVICE/normalize-space()"
             }
           },
           "targetEntityType": "#/definitions/Reference"

--- a/steps/mapping/ClaimMapping.step.json
+++ b/steps/mapping/ClaimMapping.step.json
@@ -184,7 +184,7 @@
         "date": {
           "sourcedFrom": "substring-before(./claimLine/TODATE, \"T\")"
         },
-        "procedureCodeableConcept": {
+        "code__procedureCodeableConcept__SNOMED": {
           "sourcedFrom": "./claimLine/PROCEDURECODE"
         }
       },

--- a/steps/mapping/PatientMapping.step.json
+++ b/steps/mapping/PatientMapping.step.json
@@ -156,29 +156,8 @@
     "communication": {
       "sourcedFrom": "/",
       "properties": {
-        "language": {
-          "sourcedFrom": "/",
-          "properties": {
-            "coding": {
-              "sourcedFrom": "/",
-              "properties": {
-                "system": {
-                  "sourcedFrom": "\"urn:ietf:bcp:47\""
-                },
-                "code": {
-                  "sourcedFrom": "\"en-US\""
-                },
-                "display": {
-                  "sourcedFrom": "\"English\""
-                }
-              },
-              "targetEntityType": "#/definitions/Coding"
-            },
-            "text": {
-              "sourcedFrom": "\"English\""
-            }
-          },
-          "targetEntityType": "#/definitions/CodeableConcept"
+        "code__language": {
+          "sourcedFrom": "\"en-US\""
         }
       },
       "targetEntityType": "#/definitions/Communication"


### PR DESCRIPTION
The pattern used for flattening is ```<type>__<FHIR field name>__<system>```, where:
- ```type``` can be:
  - ```code``` for codable concepts
  - ```ex``` for extensions
  - ```identifier``` for identifiers
- if ```type``` and ```FHIR field name``` are the same, ```<type>__``` is dropped (for example, we don't want ```identifier__identifier__NPI```)
- if there is only 1 system for the field, ```__<system>``` can be dropped